### PR TITLE
Content type as default view update

### DIFF
--- a/develop/plone/content/dynamic_views.rst
+++ b/develop/plone/content/dynamic_views.rst
@@ -23,11 +23,16 @@ By default, Plone comes with dynamic views for:
 * etc.
 
 The default view can be also a content item picked from the folder.
+
+Available content item types can be managed from the: Site Setup Control Panel -> Content Rules (site.com/@@content-controlpanel) -> Select your new type from the drop down menu -> Click the "Can be used as default page" checkbox. 
+
+Older versions of Plone can use the below:
+
 Available content item types can be managed from the :term:`ZMI` at
 :guilabel:`portal_properties` -> :guilabel:`site_properties` ->
 :guilabel:`default_page_types`.
 
-More info
+More info about Plone 4 and below: 
 
 * http://stackoverflow.com/questions/9432229/enabling-folder-as-one-of-default-content-item-views
 


### PR DESCRIPTION
Docs now show the correct Plone 5 method for enabling your Dexterity type to be selected as the default view of a container. "default_page_types" has been moved out of site_properties and is now configurable through the content-controlpanel. 
